### PR TITLE
Allow TI$ relocation

### DIFF
--- a/eval.s
+++ b/eval.s
@@ -466,15 +466,15 @@ LCE3B:
   .else
         ldx     #$00
         stx     STRNG1+1
-        bit     FAC+4
-        bpl     LCE53
+        bit     FAC_LAST
+        bpl     LCE53   ; XXX Assumes vars are <32K and C_ZERO lives above!
         cmp     #$54	; T
         bne     LCE53
   .endif
         cpy     #$C9	; I$
         bne     LCE53
-        jsr     LCE76
-        sty     EXPON
+        jsr     GETTIM
+        sty     EXPON   ; Y=0
         dey
         sty     STRNG2
         ldy     #$06
@@ -512,9 +512,9 @@ L2DC2:
         .byte   $19
 .endif
 .ifdef CBM2
-        bit     FAC+4
-        bpl     LCE90
-        cmp     #$54
+        bit     FAC_LAST
+        bpl     LCE90   ; XXX Assumes vars are <32K and C_ZERO lives above!
+        cmp     #$54    ; T
         bne     LCE82
 .endif
 .ifndef CONFIG_CBM_ALL
@@ -522,39 +522,34 @@ L2DC2:
 .endif
 .ifdef CONFIG_CBM_ALL
 LCE69:
-        cpy     #$49
+        cpy     #$49    ; I
 .ifdef CBM1
         bne     LCE82
 .else
         bne     LCE90
 .endif
-        jsr     LCE76
-        tya
-        ldx     #$A0
-        jmp     LDB21
-LCE76:
-.ifdef CBM1
-        lda     #$FE
-        ldy     #$01
-.else
-        lda     #$8B
-        ldy     #$00
-.endif
+        jsr     GETTIM
+        tya             ; FOR FLOAT3 (Y=0)
+        ldx     #$A0    ; EXPONENT
+        jmp     FLOAT3
+GETTIM:
+        lda     #<(TISTR-2)
+        ldy     #>(TISTR-2)
         sei
         jsr     LOAD_FAC_FROM_YA
         cli
-        sty     FAC+1
+        sty     FAC+1   ; ZERO HIGHEST.
         rts
 LCE82:
-        cmp     #$53
+        cmp     #$53    ; S
         bne     LCE90
-        cpy     #$54
+        cpy     #$54    ; T
         bne     LCE90
         lda     Z96
         jmp     FLOAT
 LCE90:
-        lda     FAC+3
-        ldy     FAC+4
+        lda     FAC_LAST-1
+        ldy     FAC_LAST
         jmp     LOAD_FAC_FROM_YA
 .endif
 

--- a/float.s
+++ b/float.s
@@ -1047,7 +1047,7 @@ FLOAT2:
         sta     FAC+4
 .endif
         sta     FAC+3
-LDB21:
+FLOAT3:
         stx     FAC
         sta     FACEXTENSION
         sta     FACSIGN
@@ -1644,10 +1644,13 @@ L3D94:
 
 ; ----------------------------------------------------------------------------
 CON_HALF:
-.ifdef CONFIG_SMALL
-        .byte   $80,$00,$00,$00
-.else
-        .byte   $80,$00,$00,$00,$00
+        .byte   $80,$00         ; 1/2
+.ifdef CONFIG_2
+C_ZERO:                         ; SIMULATED ZERO
+.endif
+        .byte   $00,$00
+.ifndef CONFIG_SMALL
+        .byte   $00
 .endif
 
 ; ----------------------------------------------------------------------------
@@ -1681,9 +1684,6 @@ DECTBL_END:
 		.byte	$00,$00,$0E,$10
 		.byte	$FF,$FF,$FD,$A8
 		.byte	$00,$00,$00,$3C
-.endif
-.ifdef CONFIG_2
-C_ZERO = CON_HALF + 2
 .endif
 
 ; ----------------------------------------------------------------------------

--- a/misc1.s
+++ b/misc1.s
@@ -102,11 +102,7 @@ LETSTRING:
 PUTSTR:
 .ifdef CONFIG_CBM_ALL
         ldy     FORPNT+1
-  .ifdef CBM1
-        cpy     #$D0	; TI$
-  .else
-        cpy     #$DE
-  .endif
+        cpy     #>C_ZERO        ; ONLY TI$ CAN BE THIS ON ASSIG.
         bne     LC92B
         jsr     FREFAC
         cmp     #$06

--- a/program.s
+++ b/program.s
@@ -437,7 +437,7 @@ L24DB:
 ; ---END OF LINE------------------
 L24EA:
         sta     INPUTBUFFER-3,y
-.ifdef CONFIG_NO_INPUTBUFFER_ZP
+.if <INPUTBUFFER = 0
         dec     TXTPTR+1
 .endif
         lda     #<INPUTBUFFER-1

--- a/var.s
+++ b/var.s
@@ -149,7 +149,7 @@ NAMENOTFOUND:
         cmp     #>FRM_VARIABLE_CALL
         bne     MAKENEWVARIABLE
 .endif
-LD015:
+LDZR:
         lda     #<C_ZERO
         ldy     #>C_ZERO
         rts
@@ -170,18 +170,18 @@ MAKENEWVARIABLE:
 .ifdef CONFIG_CBM_ALL
         lda     VARNAM
         ldy     VARNAM+1
-        cmp     #$54
+        cmp     #$54    ; T
         bne     LD02F
-        cpy     #$C9
-        beq     LD015
-        cpy     #$49
+        cpy     #$C9    ; I$
+        beq     LDZR
+        cpy     #$49    ; I
         bne     LD02F
 LD02C:
         jmp     SYNERR
 LD02F:
-        cmp     #$53
+        cmp     #$53    ; S
         bne     LD037
-        cpy     #$54
+        cpy     #$54    ; T
         beq     LD02C
 LD037:
 .endif


### PR DESCRIPTION
Flexibility I needed in the Gigatron port of cbmbasic2 to make TI$ work in a different memory layout

Most important:
- Replaced magic constants and conditional assembly with expressions
- Verified that none of the bin files change

A little housekeeping:
- Renamed related labels to original MS source
- Add comments about C_ZERO
