### PR TITLE
Removed dependency on force_range feature

### DIFF
--- a/float.s
+++ b/float.s
@@ -774,7 +774,7 @@ FDIVT:
         jsr     ADD_EXPONENTS
         inc     FAC
         beq     JOV
-        ldx     #-MANTISSA_BYTES
+        ldx     #<-MANTISSA_BYTES
         lda     #$01
 L39A1:
         ldy     ARG+1
@@ -1452,9 +1452,9 @@ L3C8C:
         ldy     #>CON_BILLION
         jsr     FMULT
 .ifdef CONFIG_SMALL
-        lda     #-6 ; exponent adjustment
+        lda     #<-6 ; exponent adjustment
 .else
-        lda     #-9
+        lda     #<-9
 .endif
 L3C95:
         sta     INDX

--- a/inline.s
+++ b/inline.s
@@ -38,8 +38,8 @@ INLIN1:
 L0C32:
         lda     #$00
         sta     INPUTBUFFER,x
-        ldx     #<INPUTBUFFER-1
-        ldy     #>INPUTBUFFER-1
+        ldx     #<(INPUTBUFFER-1)
+        ldy     #>(INPUTBUFFER-1)
         rts
   .endif
 

--- a/memory.s
+++ b/memory.s
@@ -136,7 +136,7 @@ L2300:
         dex
         bpl     L2300
         jsr     GARBAG
-        ldx     #TEMP1-FAC+1
+        ldx     #<(TEMP1-FAC+1)
 L230B:
         pla
         sta     FAC,x

--- a/msbasic.s
+++ b/msbasic.s
@@ -1,4 +1,3 @@
-.feature force_range
 .debuginfo +
 
 .setcpu "6502"

--- a/program.s
+++ b/program.s
@@ -440,7 +440,7 @@ L24EA:
 .ifdef CONFIG_NO_INPUTBUFFER_ZP
         dec     TXTPTR+1
 .endif
-        lda     #<INPUTBUFFER-1
+        lda     #<(INPUTBUFFER-1)
         sta     TXTPTR
         rts
 


### PR DESCRIPTION
Changed code so that force_range feature doesn't have to be enabled for more recent versions of CC65.