### PR TITLE
Add support for W65C816SXB dev board from WDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This lists the versions in the order in which they were forked from the Microsof
 
 The CONFIG_n defines specify what Microsoft-version the OEM version is based on. If CONFIG_2B is defined, for example, CONFIG_2A, CONFIG_2, CONFIG_11A, CONFIG_11 and CONFIG_10A will be defined as well, and all bugfixes up to version 2B will be enabled.
 
+Additionally these releases are built for computer originally not having "original" Microsoft BASIC
+| Name                | Release  | .define    |
+| ------------------- |:--------:| ---------- |
+| W65C816SXB          |  2014    | CONFIG_2C  |
+
+
 The following symbols can be defined in addition:
 
 | Configuration Symbol              | Description

--- a/defines.s
+++ b/defines.s
@@ -25,6 +25,9 @@ AIM65 := 1
 .elseif .def(sym1)
 SYM1 := 1
 .include "defines_sym1.s"
+.elseif .def(w65c816sxb)
+W65C816SXB := 1
+.include "defines_w65c816sxb.s"
 .endif
 
 .ifdef CONFIG_2C

--- a/defines_w65c816sxb.s
+++ b/defines_w65c816sxb.s
@@ -1,0 +1,26 @@
+; configuration
+CONFIG_2C := 1
+
+CONFIG_NO_CR        := 1
+CONFIG_SCRTCH_ORDER := 2
+
+; zero page
+ZP_START1 := $00
+ZP_START2 := $0D
+ZP_START3 := $5B
+ZP_START4 := $65
+
+;extra ZP variables
+USR              := $000A
+
+; constants
+STACK_TOP        := $FC
+SPACE_FOR_GOSUB  := $33
+WIDTH            := 72
+WIDTH2           := 56
+
+; memory layout
+RAMSTART2        := $5000
+SAVE:
+LOAD:
+        rts

--- a/extra.s
+++ b/extra.s
@@ -27,3 +27,7 @@
 .ifdef SYM1
         .byte   0,0,0
 .endif
+
+.ifdef W65C816SXB
+.include "w65c816sxb_extra.s"
+.endif

--- a/header.s
+++ b/header.s
@@ -1,4 +1,24 @@
 		.segment "HEADER"
+.ifdef W65C816SXB
+; Disable emulation mode (is left on from the monitor)
+.setcpu "65816"
+        SEC ;set carry for emulation mode
+        XCE ;go into emulation mode
+.setcpu "65C02"
+        jsr INITUSBSERIAL
+
+        ; Add a small delay to allow monitor to connect the terminal after
+        ; starting execution
+        ldy #0
+        ldx #0
+@loop:
+        dex
+        bne @loop
+        dey
+        bne @loop
+        jmp COLD_START
+.endif
+
 .ifdef KBD
         jmp     LE68C
         .byte   $00,$13,$56

--- a/iscntc.s
+++ b/iscntc.s
@@ -26,4 +26,7 @@
 .ifdef SYM1
 .include "sym1_iscntc.s"
 .endif
+.ifdef W65C816SXB
+.include "w65c816sxb_iscntc.s"
+.endif
 ;!!! runs into "STOP"

--- a/make.sh
+++ b/make.sh
@@ -2,7 +2,7 @@ if [ ! -d tmp ]; then
 	mkdir tmp
 fi
 
-for i in cbmbasic1 cbmbasic2 kbdbasic osi kb9 applesoft microtan aim65 sym1; do
+for i in cbmbasic1 cbmbasic2 kbdbasic osi kb9 applesoft microtan aim65 sym1 w65c816sxb; do
 
 echo $i
 ca65 -D $i msbasic.s -o tmp/$i.o &&

--- a/w65c816sxb.cfg
+++ b/w65c816sxb.cfg
@@ -1,0 +1,19 @@
+MEMORY {
+	ZP:		start = $0000, size = $0100, type = rw;
+	BASROM:		start = $1000, size = $3F00, fill = no, file = %O;
+	DUMMY:		start = $0000, size = $00FF, file = "";
+}
+
+SEGMENTS {
+	ZEROPAGE:	load = ZP, type = zp;
+	HEADER:		load = BASROM,	type = ro;
+	VECTORS:	load = BASROM,	type = ro;
+	KEYWORDS:	load = BASROM,	type = ro;
+	ERROR:		load = BASROM,	type = ro;
+	CODE:		load = BASROM,	type = ro;
+	CHRGET:		load = BASROM,	type = ro;
+	INIT:		load = BASROM,	type = ro;
+	EXTRA:		load = BASROM,	type = ro;
+	DUMMY:		load = DUMMY; # don't include
+}
+

--- a/w65c816sxb_extra.s
+++ b/w65c816sxb_extra.s
@@ -1,0 +1,92 @@
+.segment "EXTRA"
+.export MONRDKEY_NB, MONRDKEY, MONCOUT, INITUSBSERIAL
+
+VIA_USB_REG_DDRB  := $7FE2
+VIA_USB_REG_DDRA  := $7FE3
+VIA_USB_REG_PORTB := $7FE0
+VIA_USB_REG_PORTA := $7FE1
+VIA_USB_NRD       := %00001000 ; make RD# high to not output data from FTDI
+VIA_USB_WR        := %00000100 ; make WR  high to output data from FTDI
+VIA_USB_nRXF      := %00000010
+VIA_USB_DDRB_INIT := (VIA_USB_NRD+VIA_USB_WR)
+
+; INIT: Set up outputs and block reading characters from FTDI
+INITUSBSERIAL:
+        lda #(VIA_USB_NRD+VIA_USB_WR) ; Make these outputs
+        sta VIA_USB_REG_DDRB ; to DDRB
+        lda #VIA_USB_NRD ; Block RD, no WR
+        sta VIA_USB_REG_PORTB ; to REGB
+        rts
+
+MONRDKEY_NB:
+READCHAR:
+        lda VIA_USB_REG_PORTB
+        and #VIA_USB_nRXF
+
+        bne READCHAR_NOTHINGTOREAD ; Z=0 -> had no result
+
+        ; Reset DDRA as input
+        lda #$00   ; 0x00
+        sta VIA_USB_REG_DDRA ; to Directory Data (all in)
+
+        lda #0 ; DO RD, no WR
+        sta VIA_USB_REG_PORTB ; to REGB
+
+
+        lda VIA_USB_REG_PORTA
+
+        ; Save on stack temporrily
+        pha
+
+        lda #VIA_USB_NRD ; Block RD, no WR
+        sta VIA_USB_REG_PORTB ; to REGB
+
+        ; Get character back
+        pla
+        sec
+        rts
+
+READCHAR_NOTHINGTOREAD:
+        clc
+        rts
+
+MONRDKEY:
+        php
+@MONRDKEYREREAD:
+        jsr MONRDKEY_NB
+        bcc @MONRDKEYREREAD
+        ; Enable to echo back
+        ; jsr SENDCHAR
+        plp
+        rts
+
+MONCOUT:
+        ; TXE SHOULD be read before sending, but since the USB connection is
+        ; running full speed this buffer has not been seen filling up.
+
+        ; Save A for when returning
+        pha
+
+        ; Output character
+        sta VIA_USB_REG_PORTA ; to data
+
+        lda #VIA_USB_NRD      ; Block RD, no WR
+        sta VIA_USB_REG_PORTB ; to REGB
+
+        lda #$FF
+        sta VIA_USB_REG_DDRA  ; (all out)
+
+        ; Pulse WR
+        lda #(VIA_USB_NRD+VIA_USB_WR) ; Block RD, DO WR
+        sta VIA_USB_REG_PORTB         ; to REGB
+        lda #VIA_USB_NRD              ; Block RD, no WR
+        sta VIA_USB_REG_PORTB         ; to REGB
+
+        ; Reset DDRA as input
+        lda #$00
+        sta VIA_USB_REG_DDRA ; to Directory Data (all in)
+
+        ; Restore Accumulator
+        pla
+        rts
+

--- a/w65c816sxb_iscntc.s
+++ b/w65c816sxb_iscntc.s
@@ -1,0 +1,10 @@
+.segment "CODE"
+ISCNTC:
+        jsr MONRDKEY_NB
+        bcc @NOTHING
+        cmp #$03
+        beq @STOPIT
+@NOTHING:
+        rts
+@STOPIT:
+;!!! runs into "STOP"


### PR DESCRIPTION
Outputs a binary that can be run on the dev board and uses the USB port for serial communication.